### PR TITLE
#4615: Fix for fmi_import_allocate_context() passed NULL pointer, use…

### DIFF
--- a/Config.cmake/runtime_test.cmake
+++ b/Config.cmake/runtime_test.cmake
@@ -165,6 +165,7 @@ ADD_TEST(ctest_fmi_import_test_me_1 fmi_import_test ${FMU_ME_PATH} ${FMU_TEMPFOL
 ADD_TEST(ctest_fmi_import_test_cs_1 fmi_import_test ${FMU_CS_PATH} ${FMU_TEMPFOLDER})
 ADD_TEST(ctest_fmi_import_test_me_2 fmi_import_test ${FMU2_ME_PATH} ${FMU_TEMPFOLDER})
 ADD_TEST(ctest_fmi_import_test_cs_2 fmi_import_test ${FMU2_CS_PATH} ${FMU_TEMPFOLDER})
+ADD_TEST(ctest_fmi_import_test_default_callbacks fmi_import_test ${FMU_ME_PATH} ${FMU_TEMPFOLDER} 0)
 
 if(FMILIB_BUILD_BEFORE_TESTS)
 	SET_TESTS_PROPERTIES ( 

--- a/Test/fmi_import_test.c
+++ b/Test/fmi_import_test.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if(argc < 3) {
-		printf("Usage: %s <fmu_file> <temporary_dir>\n", argv[0]);
+		printf("Usage: %s <fmu_file> <temporary_dir> [0=default callbacks]\n", argv[0]);
 		do_exit(CTEST_RETURN_FAIL);
 	}
 
@@ -67,7 +67,15 @@ int main(int argc, char *argv[])
 	printf("Library build stamp:\n%s\n", fmilib_get_build_stamp());
 #endif
 
-	context = fmi_import_allocate_context(&callbacks);
+	if(argc == 4)
+	{
+	    // Allocate with default callbacks
+	    context = fmi_import_allocate_context(0);
+	}
+	else
+	{
+	    context = fmi_import_allocate_context(&callbacks);
+	}
 
 	version = fmi_import_get_fmi_version(context, FMUPath, tmpPath);
 

--- a/src/Import/src/FMI/fmi_import_context.c
+++ b/src/Import/src/FMI/fmi_import_context.c
@@ -25,9 +25,10 @@
 
 #define MODULE "FMILIB"
 
-fmi_import_context_t* fmi_import_allocate_context( jm_callbacks* callbacks) {
-	jm_log_verbose(callbacks, MODULE, "Allocating FMIL context");
-	return fmi_xml_allocate_context(callbacks);
+fmi_import_context_t* fmi_import_allocate_context(jm_callbacks* callbacks) {
+    fmi_xml_context_t *const c = fmi_xml_allocate_context(callbacks);
+    jm_log_verbose(c->callbacks, MODULE, "Allocating FMIL context");
+    return c;
 }
 
 void fmi_import_free_context( fmi_import_context_t* c) {

--- a/src/Import/src/FMI/fmi_import_util.c
+++ b/src/Import/src/FMI/fmi_import_util.c
@@ -47,6 +47,10 @@ char* fmi_import_get_dll_path(const char* fmu_unzipped_path, const char* model_i
 
 	len = strlen(fmu_unzipped_path) + strlen(FMI_FILE_SEP) + strlen(FMI_BINARIES) + strlen(FMI_FILE_SEP) + strlen(FMI_PLATFORM) + strlen(FMI_FILE_SEP) + strlen(model_identifier) + strlen(FMI_DLL_EXT) + 1;
 
+	if(!callbacks)
+	{
+	    callbacks = jm_get_default_callbacks();
+	}
 	dll_path = (char*)callbacks->calloc(len, sizeof(char));
 	if (dll_path == NULL) {
 		jm_log_fatal(callbacks, "FMILIB", "Failed to allocate memory.");
@@ -65,6 +69,10 @@ char* fmi_import_get_model_description_path(const char* fmu_unzipped_path, jm_ca
 
 	len = strlen(fmu_unzipped_path) + strlen(FMI_FILE_SEP) + strlen(FMI_MODEL_DESCRIPTION_XML) + 1;
 
+	if(!callbacks)
+	{
+	    callbacks = jm_get_default_callbacks();
+	}
 	model_description_path = (char*)callbacks->calloc(len, sizeof(char));
 	if (model_description_path == NULL) {
 		callbacks->logger(NULL, "FMIIMPORTUTIL", jm_log_level_error, "Failed to allocate memory.");

--- a/src/Util/src/FMI/fmi_util.c
+++ b/src/Util/src/FMI/fmi_util.c
@@ -22,13 +22,16 @@ char* fmi_construct_dll_dir_name(jm_callbacks* callbacks, const char* fmu_unzipp
 	char* dir_path;
 	size_t len;
 
-	assert( fmu_unzipped_path && callbacks);
+	assert(fmu_unzipped_path);
 
 	len = 
 		strlen(fmu_unzipped_path) + strlen(FMI_FILE_SEP)
 		+ strlen(FMI_BINARIES) + strlen(FMI_FILE_SEP) 
 		+ strlen(FMI_PLATFORM) + strlen(FMI_FILE_SEP) + 1;
 
+	if(!callbacks) {
+	    callbacks = jm_get_default_callbacks();
+	}
 	dir_path = (char*)callbacks->malloc(len);
 	if (dir_path == NULL) {
 		jm_log_fatal(callbacks, "FMIUT", "Failed to allocate memory.");
@@ -43,11 +46,14 @@ char* fmi_construct_dll_dir_name(jm_callbacks* callbacks, const char* fmu_unzipp
 char* fmi_construct_dll_file_name(jm_callbacks* callbacks, const char* dll_dir_name, const char* model_identifier) {
 	char* fname;
 	size_t len;
-	assert(callbacks && model_identifier);
+	assert(model_identifier);
 	len = 
 		strlen(dll_dir_name) +
 		strlen(model_identifier) 
 		+ strlen(FMI_DLL_EXT) + 1;
+	if(!callbacks) {
+	    callbacks = jm_get_default_callbacks();
+	}
 	fname = (char*)callbacks->malloc(len);
 	if (fname == NULL) {
 		jm_log_fatal(callbacks, "FMIUT", "Failed to allocate memory.");

--- a/src/Util/src/JM/jm_portability.c
+++ b/src/Util/src/JM/jm_portability.c
@@ -169,10 +169,10 @@ jm_status_enu_t jm_rmdir(jm_callbacks* cb, const char* dir) {
 #else
     const char* fmt_cmd = "rm -rf %s";
 #endif
-    char * buf = (char*)cb->calloc(sizeof(char), strlen(dir)+strlen(fmt_cmd)+1);
 	if(!cb) {
 		cb = jm_get_default_callbacks();
 	}
+    char * buf = (char*)cb->calloc(sizeof(char), strlen(dir)+strlen(fmt_cmd)+1);
 	if(!buf) {
 	    jm_log_error(cb,module,"Could not allocate memory");
 		return jm_status_error;

--- a/src/XML/src/FMI/fmi_xml_context.c
+++ b/src/XML/src/FMI/fmi_xml_context.c
@@ -22,18 +22,14 @@
 static char* MODULE="FMIXML";
 
 fmi_xml_context_t* fmi_xml_allocate_context( jm_callbacks* callbacks) {
-	jm_callbacks* cb;
 	fmi_xml_context_t* c;
 
 	jm_log_debug(callbacks, MODULE, "Allocating context for XML parsing module");
 
-    if(callbacks) {
-        cb = callbacks;
-    }
-    else {
-        cb = jm_get_default_callbacks();
-    }
-    c = cb->malloc(sizeof(fmi_xml_context_t));
+	if(!callbacks) {
+	    callbacks = jm_get_default_callbacks();
+	}
+    c = callbacks->malloc(sizeof(fmi_xml_context_t));
     if(!c) {
 		jm_log_fatal(callbacks, MODULE, "Could not allocate memory");
 		return 0;


### PR DESCRIPTION
… default callbacks. Various fixes for broken checks for NULL callbacks pointer.
